### PR TITLE
fix: config command and naming conventions

### DIFF
--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -76,8 +76,8 @@ services:
       - DASHCORE_P2P_PORT=${CORE_P2P_PORT:?err}
       - DASHCORE_P2P_NETWORK=devnet
       - NETWORK=devnet
-      - TENDERDASH_RPC_HOST=drive_tenderdash
-      - TENDERDASH_RPC_PORT=26657
+      - TENDERMINT_RPC_HOST=drive_tenderdash
+      - TENDERMINT_RPC_PORT=26657
       - NODE_ENV=${ENVIRONMENT:?err}
     command: npm run api
 
@@ -100,8 +100,8 @@ services:
       - DASHCORE_P2P_PORT=${CORE_P2P_PORT:?err}
       - DASHCORE_P2P_NETWORK=devnet
       - NETWORK=devnet
-      - TENDERDASH_RPC_HOST=drive_tenderdash
-      - TENDERDASH_RPC_PORT=26657
+      - TENDERMINT_RPC_HOST=drive_tenderdash
+      - TENDERMINT_RPC_PORT=26657
     command: npm run tx-filter-stream
 
   dapi_envoy:

--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -76,8 +76,8 @@ services:
       - DASHCORE_P2P_PORT=${CORE_P2P_PORT:?err}
       - DASHCORE_P2P_NETWORK=devnet
       - NETWORK=devnet
-      - TENDERMINT_RPC_HOST=drive_tenderdash
-      - TENDERMINT_RPC_PORT=26657
+      - TENDERDASH_RPC_HOST=drive_tenderdash
+      - TENDERDASH_RPC_PORT=26657
       - NODE_ENV=${ENVIRONMENT:?err}
     command: npm run api
 
@@ -100,8 +100,8 @@ services:
       - DASHCORE_P2P_PORT=${CORE_P2P_PORT:?err}
       - DASHCORE_P2P_NETWORK=devnet
       - NETWORK=devnet
-      - TENDERMINT_RPC_HOST=drive_tenderdash
-      - TENDERMINT_RPC_PORT=26657
+      - TENDERDASH_RPC_HOST=drive_tenderdash
+      - TENDERDASH_RPC_PORT=26657
     command: npm run tx-filter-stream
 
   dapi_envoy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4334,7 +4334,7 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
+      "version": "github:jawid-h/protobuf.js#264b99b2ab6e097ff5350a57055d754d44d8e703",
       "from": "github:jawid-h/protobuf.js#fix/buffer-conversion",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/src/commands/restart.js
+++ b/src/commands/restart.js
@@ -63,9 +63,9 @@ class RestartCommand extends BaseCommand {
   }
 }
 
-RestartCommand.description = `Restart masternode
+RestartCommand.description = `Restart node
 ...
-Restart masternode with specific preset
+Restart node
 `;
 
 RestartCommand.flags = {

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -59,9 +59,9 @@ class StartCommand extends BaseCommand {
   }
 }
 
-StartCommand.description = `Start masternode
+StartCommand.description = `Start node
 ...
-Start masternode with specific preset
+Start node
 `;
 
 StartCommand.flags = {

--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -6,6 +6,7 @@ const BaseCommand = require('../../oclif/command/BaseCommand');
 const CoreService = require('../../core/CoreService');
 
 const ContainerIsNotPresentError = require('../../docker/errors/ContainerIsNotPresentError');
+const ServiceIsNotRunningError = require('../../docker/errors/ServiceIsNotRunningError');
 
 class CoreStatusCommand extends BaseCommand {
   /**
@@ -45,6 +46,10 @@ class CoreStatusCommand extends BaseCommand {
     const explorerURLs = {
       evonet: 'https://rpc.cloudwheels.net:26657/status',
     };
+
+    if (!(await dockerCompose.isServiceRunning(config.toEnvs(), 'drive_tenderdash'))) {
+      throw new ServiceIsNotRunningError(config.options.network, 'drive_tenderdash');
+    }
 
     // Collect core data
     const {

--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -61,7 +61,7 @@ class CoreStatusCommand extends BaseCommand {
     }
 
     // Collect platform data
-    const tendermintStatusRes = await fetch(`http://localhost:${config.options.platform.drive.tendermint.rpc.port}/status`);
+    const tenderdashStatusRes = await fetch(`http://localhost:${config.options.platform.drive.tenderdash.rpc.port}/status`);
     const {
       result: {
         node_info: {
@@ -74,14 +74,14 @@ class CoreStatusCommand extends BaseCommand {
           latest_block_height: platformLatestBlockHeight,
         },
       },
-    } = await tendermintStatusRes.json();
+    } = await tenderdashStatusRes.json();
 
-    const tendermintNetInfoRes = await fetch(`http://localhost:${config.options.platform.drive.tendermint.rpc.port}/net_info`);
+    const tenderdashNetInfoRes = await fetch(`http://localhost:${config.options.platform.drive.tenderdash.rpc.port}/net_info`);
     const {
       result: {
         n_peers: platformPeers,
       },
-    } = await tendermintNetInfoRes.json();
+    } = await tenderdashNetInfoRes.json();
 
     let explorerLatestBlockHeight;
     if (explorerURLs[config.options.network]) {
@@ -100,7 +100,7 @@ class CoreStatusCommand extends BaseCommand {
     let httpPortState = await httpPortStateRes.text();
     const gRpcPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.grpc.port}/`);
     let gRpcPortState = await gRpcPortStateRes.text();
-    const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tendermint.p2p.port}/`);
+    const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tenderdash.p2p.port}/`);
     let p2pPortState = await p2pPortStateRes.text();
 
     // Determine status
@@ -110,7 +110,7 @@ class CoreStatusCommand extends BaseCommand {
         State: {
           Status: status,
         },
-      } = await dockerCompose.inspectService(config.toEnvs(), 'drive_tendermint'));
+      } = await dockerCompose.inspectService(config.toEnvs(), 'drive_tenderdash'));
     } catch (e) {
       if (e instanceof ContainerIsNotPresentError) {
         status = 'not started';
@@ -170,9 +170,9 @@ class CoreStatusCommand extends BaseCommand {
     rows.push(['HTTP port', `${config.options.platform.dapi.nginx.http.port} ${httpPortState}`]);
     rows.push(['gRPC service', `${config.options.externalIp}:${config.options.platform.dapi.nginx.grpc.port}`]);
     rows.push(['gRPC port', `${config.options.platform.dapi.nginx.grpc.port} ${gRpcPortState}`]);
-    rows.push(['P2P service', `${config.options.externalIp}:${config.options.platform.drive.tendermint.p2p.port}`]);
-    rows.push(['P2P port', `${config.options.platform.drive.tendermint.p2p.port} ${p2pPortState}`]);
-    rows.push(['RPC service', `127.0.0.1:${config.options.platform.drive.tendermint.rpc.port}`]);
+    rows.push(['P2P service', `${config.options.externalIp}:${config.options.platform.drive.tenderdash.p2p.port}`]);
+    rows.push(['P2P port', `${config.options.platform.drive.tenderdash.p2p.port} ${p2pPortState}`]);
+    rows.push(['RPC service', `127.0.0.1:${config.options.platform.drive.tenderdash.rpc.port}`]);
     const output = table(rows, { singleLine: true });
 
     // eslint-disable-next-line no-console

--- a/src/docker/DockerCompose.js
+++ b/src/docker/DockerCompose.js
@@ -152,7 +152,7 @@ class DockerCompose {
     await this.throwErrorIfNotInstalled();
 
     if (!(await this.isServiceRunning(envs, serviceName))) {
-      throw new ServiceIsNotRunningError(envs, serviceName);
+      throw new ServiceIsNotRunningError(envs.NETWORK, serviceName);
     }
 
     let commandOutput;

--- a/src/docker/errors/ServiceIsNotRunningError.js
+++ b/src/docker/errors/ServiceIsNotRunningError.js
@@ -2,23 +2,23 @@ const AbstractError = require('../../errors/AbstractError');
 
 class ServiceIsNotRunningError extends AbstractError {
   /**
-   * @param {string} preset
+   * @param {string} network
    * @param {string} serviceName
    */
-  constructor(preset, serviceName) {
-    super(`Service ${serviceName} for ${preset} is not running. Please run the service first.`);
+  constructor(network, serviceName) {
+    super(`Service ${serviceName} for ${network} is not running. Please run the service first.`);
 
-    this.preset = preset;
+    this.network = network;
     this.serviceName = serviceName;
   }
 
   /**
-   * Get preset
+   * Get network
    *
    * @return {string}
    */
-  getPreset() {
-    return this.preset;
+  getNetwork() {
+    return this.network;
   }
 
   /**

--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -129,7 +129,7 @@ function initTaskFactory(
           const response = await tenderdashRpcClient.request('tx', params);
 
           if (response.error) {
-            throw new Error(`Tendermint error: ${response.error.message}: ${response.error.data}`);
+            throw new Error(`Tenderdash error: ${response.error.message}: ${response.error.data}`);
           }
 
           const { result: { height: contractBlockHeight } } = response;


### PR DESCRIPTION
Rename tendermint -> tenderdash and check platform is running before querying

## Issue being fixed or feature implemented
The updated config command was written before tendermint was renamed to tenderdash, causing errors. The `status:platform` command was also attempting to query tenderdash without verifying if it was running first, resulting in uncaught errors.

## What was done?
- rename tendermint -> tenderdash
- check if tenderdash is running before querying
- remove legacy references to presets, use network configs instead
- small consistency change to help output


## How Has This Been Tested?
Tested on a node with core running but platform not running.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
