### PR TITLE
fix: rmdir and tenderdash errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4374,7 +4374,7 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
+      "version": "github:jawid-h/protobuf.js#264b99b2ab6e097ff5350a57055d754d44d8e703",
       "from": "github:jawid-h/protobuf.js#fix/buffer-conversion",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -11,6 +11,8 @@ const MuteOneLineError = require('../oclif/errors/MuteOneLineError');
 
 const wait = require('../util/wait');
 
+const packageJson = require('../../package.json');
+
 const PRESET_TESETNET = 'testnet';
 const PRESET_LOCAL = 'local';
 const PRESET_EVONET = 'evonet';
@@ -76,6 +78,9 @@ class SetupCommand extends BaseCommand {
 
     const amount = 10000;
 
+    // eslint-disable-next-line no-console
+    console.log(`dashman ${packageJson.version}\n`);
+
     const tasks = new Listr([
       {
         title: 'Set configuration preset',
@@ -97,7 +102,6 @@ class SetupCommand extends BaseCommand {
 
           // eslint-disable-next-line no-param-reassign
           task.output = `Selected ${config.getName()} as default config\n`;
-
         },
         options: { persistentOutput: true },
       },

--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -61,7 +61,7 @@ class CoreStatusCommand extends BaseCommand {
     }
 
     // Collect platform data
-    const tendermintStatusRes = await fetch(`http://localhost:${config.options.platform.drive.tendermint.rpc.port}/status`);
+    const tenderdashStatusRes = await fetch(`http://localhost:${config.options.platform.drive.tenderdash.rpc.port}/status`);
     const {
       result: {
         node_info: {
@@ -74,14 +74,14 @@ class CoreStatusCommand extends BaseCommand {
           latest_block_height: platformLatestBlockHeight,
         },
       },
-    } = await tendermintStatusRes.json();
+    } = await tenderdashStatusRes.json();
 
-    const tendermintNetInfoRes = await fetch(`http://localhost:${config.options.platform.drive.tendermint.rpc.port}/net_info`);
+    const tenderdashNetInfoRes = await fetch(`http://localhost:${config.options.platform.drive.tenderdash.rpc.port}/net_info`);
     const {
       result: {
         n_peers: platformPeers,
       },
-    } = await tendermintNetInfoRes.json();
+    } = await tenderdashNetInfoRes.json();
 
     let explorerLatestBlockHeight;
     if (explorerURLs[config.options.network]) {
@@ -100,7 +100,7 @@ class CoreStatusCommand extends BaseCommand {
     let httpPortState = await httpPortStateRes.text();
     const gRpcPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.dapi.nginx.grpc.port}/`);
     let gRpcPortState = await gRpcPortStateRes.text();
-    const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tendermint.p2p.port}/`);
+    const p2pPortStateRes = await fetch(`https://mnowatch.org/${config.options.platform.drive.tenderdash.p2p.port}/`);
     let p2pPortState = await p2pPortStateRes.text();
 
     // Determine status
@@ -110,7 +110,7 @@ class CoreStatusCommand extends BaseCommand {
         State: {
           Status: status,
         },
-      } = await dockerCompose.inspectService(config.toEnvs(), 'drive_tendermint'));
+      } = await dockerCompose.inspectService(config.toEnvs(), 'drive_tenderdash'));
     } catch (e) {
       if (e instanceof ContainerIsNotPresentError) {
         status = 'not started';
@@ -170,9 +170,9 @@ class CoreStatusCommand extends BaseCommand {
     rows.push(['HTTP port', `${config.options.platform.dapi.nginx.http.port} ${httpPortState}`]);
     rows.push(['gRPC service', `${config.options.externalIp}:${config.options.platform.dapi.nginx.grpc.port}`]);
     rows.push(['gRPC port', `${config.options.platform.dapi.nginx.grpc.port} ${gRpcPortState}`]);
-    rows.push(['P2P service', `${config.options.externalIp}:${config.options.platform.drive.tendermint.p2p.port}`]);
-    rows.push(['P2P port', `${config.options.platform.drive.tendermint.p2p.port} ${p2pPortState}`]);
-    rows.push(['RPC service', `127.0.0.1:${config.options.platform.drive.tendermint.rpc.port}`]);
+    rows.push(['P2P service', `${config.options.externalIp}:${config.options.platform.drive.tenderdash.p2p.port}`]);
+    rows.push(['P2P port', `${config.options.platform.drive.tenderdash.p2p.port} ${p2pPortState}`]);
+    rows.push(['RPC service', `127.0.0.1:${config.options.platform.drive.tenderdash.rpc.port}`]);
     const output = table(rows, { singleLine: true });
 
     // eslint-disable-next-line no-console

--- a/src/listr/tasks/platform/initTaskFactory.js
+++ b/src/listr/tasks/platform/initTaskFactory.js
@@ -130,7 +130,7 @@ function initTaskFactory(
           const response = await tenderdashRpcClient.request('tx', params);
 
           if (response.error) {
-            throw new Error(`Tendermint error: ${response.error.message}: ${response.error.data}`);
+            throw new Error(`Tenderdash error: ${response.error.message}: ${response.error.data}`);
           }
 
           const { result: { height: contractBlockHeight } } = response;
@@ -206,7 +206,7 @@ function initTaskFactory(
           const response = await tenderdashRpcClient.request('tx', params);
 
           if (response.error) {
-            throw new Error(`Tendermint error: ${response.error.message}: ${response.error.data}`);
+            throw new Error(`Tenderdash error: ${response.error.message}: ${response.error.data}`);
           }
 
           const { result: { height: contractBlockHeight } } = response;

--- a/src/templates/renderServiceTemplatesFactory.js
+++ b/src/templates/renderServiceTemplatesFactory.js
@@ -4,10 +4,9 @@ const dots = require('dot');
 const glob = require('glob');
 
 /**
- * @param {string} homeDirPath
  * @return {renderServiceTemplates}
  */
-function renderServiceTemplatesFactory(homeDirPath) {
+function renderServiceTemplatesFactory() {
   /**
    * Render templates for services
    *

--- a/src/templates/writeServiceConfigsFactory.js
+++ b/src/templates/writeServiceConfigsFactory.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 
 /**
  * @param {string} homeDirPath
@@ -18,7 +19,7 @@ function writeServiceConfigsFactory(homeDirPath) {
   function writeServiceConfigs(configName, configFiles) {
     // Drop all files from configs directory
     const configDir = path.join(homeDirPath, configName);
-    fs.rmdirSync(configDir, { recursive: true });
+    rimraf.sync(configDir);
 
     for (const filePath of Object.keys(configFiles)) {
       const absoluteFilePath = path.join(configDir, filePath);


### PR DESCRIPTION
Fixes several errors and crashes relating to rmdir errors and tendermint -> tenderdash renaming. Also adds a version number when running `dashman setup`.

## Issue being fixed or feature implemented
Fixes:
- multiple errors relating to tendermint/tenderdash renaming
- error if tenderdash up but not responding due to abci error
- `dashman config` was failing with the following errors: 
  - `✖ ENOENT: no such file or directory, rmdir '/home/strophy/.dashman/testnet'`
  - `    Error: ENOTEMPTY: directory not empty, rmdir '/home/strophy/.dashman/testnet'`


## What was done?
- rename tendermint -> tenderdash
- try/catch when calling tenderdash status
- switch to rimraf
- add version number
- linting


## How Has This Been Tested?
Tested locally


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
