### PR TITLE
fix: handle node down errors in status command

### DIFF
--- a/src/commands/status/platform.js
+++ b/src/commands/status/platform.js
@@ -6,6 +6,7 @@ const BaseCommand = require('../../oclif/command/BaseCommand');
 const CoreService = require('../../core/CoreService');
 
 const ContainerIsNotPresentError = require('../../docker/errors/ContainerIsNotPresentError');
+const ServiceIsNotRunningError = require('../../docker/errors/ServiceIsNotRunningError');
 
 class CoreStatusCommand extends BaseCommand {
   /**
@@ -45,6 +46,10 @@ class CoreStatusCommand extends BaseCommand {
     const explorerURLs = {
       evonet: 'https://rpc.cloudwheels.net:26657/status',
     };
+
+    if (!(await dockerCompose.isServiceRunning(config.toEnvs(), 'drive_tenderdash'))) {
+      throw new ServiceIsNotRunningError(config.options.network, 'drive_tenderdash');
+    }
 
     // Collect core data
     const {


### PR DESCRIPTION
improved checking and catching of errors when nodes might not respond

## Issue being fixed or feature implemented
This PR prevents errors when querying nodes which might not be able to respond yet


## What was done?
wrap query functions in try/catch syntax


## How Has This Been Tested?
Tested together with other PRs


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
